### PR TITLE
feat(ui): Navbar, Card, and Footer components (Tailwind v4, themed)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 
-type Props = {}
-
-const Home = (props: Props) => {
+const Home = () => {
   return (
     <div className='text-heading-1 font-jost'>Nike</div>
   )

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import Image from "next/image";
+import Link from "next/link";
+
+type BadgeTone = "orange" | "green" | "red";
+
+export interface CardProps {
+  imageSrc: string;
+  imageAlt?: string;
+  title: string;
+  subtitle?: string;
+  meta?: string;
+  price?: string | number;
+  badge?: { label: string; tone?: BadgeTone };
+  href?: string;
+  className?: string;
+}
+
+const toneMap: Record<BadgeTone, { bg: string; fg: string }> = {
+  orange: { bg: "bg-[--color-orange]/10", fg: "text-[--color-orange]" },
+  green: { bg: "bg-[--color-green]/10", fg: "text-[--color-green]" },
+  red: { bg: "bg-[--color-red]/10", fg: "text-[--color-red]" },
+};
+
+export default function Card({
+  imageSrc,
+  imageAlt,
+  title,
+  subtitle,
+  meta,
+  price,
+  badge,
+  href,
+  className,
+}: CardProps) {
+  const content = (
+    <div
+      className={`group relative overflow-hidden rounded-xl bg-[--color-light-100] shadow-sm transition hover:shadow-md ${className || ""}`}
+    >
+      {badge ? (
+        <div
+          className={`absolute left-4 top-4 z-10 ${toneMap[badge.tone || "orange"].bg} ${toneMap[badge.tone || "orange"].fg} rounded-full px-4 py-1 text-[--text-caption] leading-[--text-caption--line-height] font-[--text-caption--font-weight]`}
+        >
+          {badge.label}
+        </div>
+      ) : null}
+
+      <div className="relative aspect-[4/3] w-full overflow-hidden">
+        <Image
+          src={imageSrc}
+          alt={imageAlt || title}
+          fill
+          sizes="(min-width: 1024px) 25vw, (min-width: 768px) 40vw, 100vw"
+          className="object-cover transition-transform duration-300 md:group-hover:scale-105"
+          priority={false}
+        />
+      </div>
+
+      <div className="bg-[--color-dark-900] px-4 py-4 text-[--color-light-100]">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <h3 className="truncate text-[--text-heading-3] leading-[--text-heading-3--line-height] font-[--text-heading-3--font-weight]">
+              {title}
+            </h3>
+            {subtitle ? (
+              <p className="mt-1 truncate text-[--text-body] leading-[--text-body--line-height] text-[--color-light-400]">
+                {subtitle}
+              </p>
+            ) : null}
+            {meta ? (
+              <p className="mt-1 truncate text-[--text-body] leading-[--text-body--line-height] text-[--color-light-400]">
+                {meta}
+              </p>
+            ) : null}
+          </div>
+          {price !== undefined ? (
+            <div className="shrink-0 text-right text-[--text-heading-3] leading-[--text-heading-3--line-height] font-[--text-heading-3--font-weight]">
+              {typeof price === "number" ? `$${price.toFixed(2)}` : price}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className="block">
+        {content}
+      </Link>
+    );
+  }
+
+  return content;
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,144 @@
+import React from "react";
+import Image from "next/image";
+
+export type FooterItem = { label: string; href?: string };
+export type FooterSection = { heading: string; items: FooterItem[] };
+
+export interface FooterProps {
+  sections?: FooterSection[];
+  year?: number;
+  regionLabel?: string;
+  className?: string;
+}
+
+const defaultSections: FooterSection[] = [
+  {
+    heading: "Featured",
+    items: [{ label: "Air Force 1" }, { label: "Huarache" }, { label: "Air Max 90" }, { label: "Air Max 95" }],
+  },
+  {
+    heading: "Shoes",
+    items: [{ label: "All Shoes" }, { label: "Custom Shoes" }, { label: "Jordan Shoes" }, { label: "Running Shoes" }],
+  },
+  {
+    heading: "Clothing",
+    items: [{ label: "All Clothing" }, { label: "Modest Wear" }, { label: "Hoodies & Pullovers" }, { label: "Shirts & Tops" }],
+  },
+  {
+    heading: "Kids'",
+    items: [
+      { label: "Infant & Toddler Shoes" },
+      { label: "Kids' Shoes" },
+      { label: "Kids' Jordan Shoes" },
+      { label: "Kids' Basketball Shoes" },
+    ],
+  },
+];
+
+export default function Footer({
+  sections = defaultSections,
+  year = new Date().getFullYear(),
+  regionLabel = "Croatia",
+  className,
+}: FooterProps) {
+  return (
+    <footer className={`bg-[--color-dark-900] text-[--color-light-100] ${className || ""}`}>
+      <div className="mx-auto max-w-7xl px-4 pb-6 pt-10 sm:px-6 lg:px-8">
+        <div className="flex flex-col gap-8 md:flex-row md:items-start md:justify-between">
+          <div className="flex items-center">
+            <Image
+              src="/logo.svg"
+              alt="Brand logo"
+              width={64}
+              height={24}
+              className="invert"
+              priority
+            />
+          </div>
+
+          <div className="grid flex-1 grid-cols-2 gap-8 md:grid-cols-4">
+            {sections.map((sec) => (
+              <div key={sec.heading}>
+                <h4 className="text-[--text-heading-3] leading-[--text-heading-3--line-height] font-[--text-heading-3--font-weight]">
+                  {sec.heading}
+                </h4>
+                <ul className="mt-3 space-y-2">
+                  {sec.items.map((it) => (
+                    <li key={it.label}>
+                      <a
+                        href={it.href || "#"}
+                        className="text-[--color-light-400] hover:text-[--color-light-100] focus:outline-none focus-visible:ring-2 focus-visible:ring-white/20 rounded-sm"
+                      >
+                        {it.label}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+            <div className="hidden items-start justify-end gap-4 md:flex">
+              <a
+                href="#"
+                aria-label="X"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-[--color-light-100] text-[--color-dark-900]"
+              >
+                <Image src="/x.svg" alt="X" width={18} height={18} />
+              </a>
+              <a
+                href="#"
+                aria-label="Facebook"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-[--color-light-100] text-[--color-dark-900]"
+              >
+                <Image src="/facebook.svg" alt="Facebook" width={18} height={18} />
+              </a>
+              <a
+                href="#"
+                aria-label="Instagram"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-[--color-light-100] text-[--color-dark-900]"
+              >
+                <Image src="/instagram.svg" alt="Instagram" width={18} height={18} />
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-10 flex flex-col items-start gap-4 border-t border-white/10 pt-6 text-[--color-light-400] md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-2">
+            <Image src="/globe.svg" alt="" aria-hidden width={16} height={16} className="invert" />
+            <span className="text-[--text-caption] leading-[--text-caption--line-height]">{regionLabel}</span>
+            <span className="text-[--text-caption] leading-[--text-caption--line-height]">© {year} Nike, Inc. All Rights Reserved</span>
+          </div>
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+            <a href="#" className="hover:text-[--color-light-100]">Guides</a>
+            <a href="#" className="hover:text-[--color-light-100]">Terms of Sale</a>
+            <a href="#" className="hover:text-[--color-light-100]">Terms of Use</a>
+            <a href="#" className="hover:text-[--color-light-100]">Nike Privacy Policy</a>
+          </div>
+          <div className="flex items-start justify-end gap-4 md:hidden">
+            <a
+              href="#"
+              aria-label="X"
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-[--color-light-100] text-[--color-dark-900]"
+            >
+              <Image src="/x.svg" alt="X" width={18} height={18} />
+            </a>
+            <a
+              href="#"
+              aria-label="Facebook"
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-[--color-light-100] text-[--color-dark-900]"
+            >
+              <Image src="/facebook.svg" alt="Facebook" width={18} height={18} />
+            </a>
+            <a
+              href="#"
+              aria-label="Instagram"
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-[--color-light-100] text-[--color-dark-900]"
+            >
+              <Image src="/instagram.svg" alt="Instagram" width={18} height={18} />
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,132 @@
+import React, { useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+
+export type NavLink = {
+  label: string;
+  href?: string;
+};
+
+export interface NavbarProps {
+  links?: NavLink[];
+  cartCount?: number;
+  className?: string;
+  onMenuToggle?: (open: boolean) => void;
+}
+
+const defaultLinks: NavLink[] = [
+  { label: "Men", href: "#" },
+  { label: "Women", href: "#" },
+  { label: "Kids", href: "#" },
+  { label: "Collections", href: "#" },
+  { label: "Contact", href: "#" },
+];
+
+export default function Navbar({
+  links = defaultLinks,
+  cartCount = 0,
+  className,
+  onMenuToggle,
+}: NavbarProps) {
+  const [open, setOpen] = useState(false);
+
+  const toggle = () => {
+    const next = !open;
+    setOpen(next);
+    onMenuToggle?.(next);
+  };
+
+  return (
+    <header
+      className={`w-full border-b border-[--color-light-300] bg-[--color-light-100] ${className || ""}`}
+    >
+      <nav
+        aria-label="Primary"
+        className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8"
+      >
+        <div className="flex items-center gap-2">
+          <Link href="/" className="flex items-center">
+            <Image
+              src="/logo.svg"
+              alt="Brand logo"
+              width={36}
+              height={36}
+              className="h-6 w-8 sm:h-7 sm:w-9"
+              priority
+            />
+          </Link>
+        </div>
+
+        <ul className="hidden items-center gap-8 md:flex">
+          {links.map((l) => (
+            <li key={l.label}>
+              <a
+                href={l.href || "#"}
+                className="text-[--color-dark-900] text-[--text-body] leading-[--text-body--line-height] font-[--text-body--font-weight] hover:text-[--color-dark-700] focus:outline-none focus-visible:ring-2 focus-visible:ring-[--color-dark-900]/20 rounded-sm"
+              >
+                {l.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+
+        <div className="hidden items-center gap-6 md:flex">
+          <span className="text-[--color-dark-900] text-[--text-body] leading-[--text-body--line-height]">
+            Search
+          </span>
+          <span className="text-[--color-dark-900] text-[--text-body] leading-[--text-body--line-height]">
+            My Cart ({cartCount})
+          </span>
+        </div>
+
+        <div className="md:hidden">
+          <button
+            type="button"
+            aria-label="Open menu"
+            aria-expanded={open}
+            aria-controls="mobile-menu"
+            onClick={toggle}
+            className="inline-flex items-center justify-center rounded-md p-2 text-[--color-dark-900] outline-none focus-visible:ring-2 focus-visible:ring-[--color-dark-900]/20"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              className="h-6 w-6"
+              aria-hidden="true"
+            >
+              <path strokeWidth="2" strokeLinecap="round" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          </button>
+        </div>
+      </nav>
+
+      <div
+        id="mobile-menu"
+        className={`md:hidden ${open ? "block" : "hidden"} border-t border-[--color-light-300] bg-[--color-light-100]`}
+      >
+        <div className="mx-auto max-w-7xl px-4 py-3 sm:px-6">
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+              <span className="text-[--color-dark-900]">Search</span>
+              <span className="text-[--color-dark-900]">My Cart ({cartCount})</span>
+            </div>
+            <ul className="flex flex-col gap-2">
+              {links.map((l) => (
+                <li key={l.label}>
+                  <a
+                    href={l.href || "#"}
+                    className="block rounded-md px-1 py-2 text-[--color-dark-900] hover:bg-[--color-light-200] focus:outline-none focus-visible:ring-2 focus-visible:ring-[--color-dark-900]/20"
+                    onClick={() => setOpen(false)}
+                  >
+                    {l.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
# feat(ui): Navbar, Card, and Footer components (Tailwind v4, themed)

## Summary
Added three responsive React components following the provided Nike-style designs:

- **Navbar.tsx**: Responsive header with logo, navigation links, search/cart placeholders, and mobile hamburger menu with state management
- **Card.tsx**: Generic product card component supporting image, title, subtitle, price, and optional colored badges (orange/green/red) 
- **Footer.tsx**: Multi-column footer with navigation sections, social media icons, and responsive layout

All components use TypeScript interfaces for props, Tailwind CSS with custom CSS variables from the theme system, and follow mobile-first responsive patterns. Also includes a minor lint fix to remove unused Props type in page.tsx.

## Review & Testing Checklist for Human

**⚠️ Important: These components were not visually tested due to local environment limitations (missing DB env). Visual verification is critical.**

- [ ] **Visual comparison**: Compare components against the provided design mockups to ensure styling accuracy
- [ ] **Mobile responsiveness**: Test on various screen sizes, especially mobile hamburger menu toggle functionality  
- [ ] **Asset loading**: Verify all referenced assets load correctly (`/logo.svg`, `/x.svg`, `/facebook.svg`, `/instagram.svg`, `/globe.svg`)
- [ ] **Theme integration**: Check that CSS custom properties render correctly (colors, typography, spacing match globals.css)
- [ ] **Interactive elements**: Test navbar mobile menu state, hover effects, and focus states for accessibility

### Test Plan
1. Import and render each component in a test page
2. Test with various prop combinations (especially Card with/without badge, different badge tones)
3. Verify responsive breakpoints on mobile/tablet/desktop
4. Check color contrast and typography rendering

### Notes
- Components follow existing patterns from ProductCard.tsx for Next.js Image usage
- Default props provided so components render without configuration
- Link to Devin run: https://app.devin.ai/sessions/4c809a87897a4d358dfa533497a1af73
- Requested by: Tawanda Jaure (@jaure-94)